### PR TITLE
[codex] Streamline report finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Streamlined report finalization by driving report generation and artifact
+  logging from one internal artifact list, reducing duplicated output-path
+  handling without changing report formats.
 - Fail the shared quality hooks when Pyrefly emits warnings so non-blocking
   type-cleanup regressions do not slip past `make quality` and pre-push checks.
 - Refactor report assembly toward shared Markdown/HTML section primitives and

--- a/docs/superpowers/plans/2026-05-10-report-finalization-cleanup.md
+++ b/docs/superpowers/plans/2026-05-10-report-finalization-cleanup.md
@@ -1,0 +1,283 @@
+# Report Finalization Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate report artifact generation and logging behind one small internal artifact list.
+
+**Architecture:** Keep `src/check_models.py` as the project monolith. Add a private `ReportArtifact` dataclass near the report/finalization helpers, construct artifacts from `ReportGenerationInputs`, and use the artifact list for report jobs, directory creation, and success-path logging.
+
+**Tech Stack:** Python 3.13, dataclasses, pathlib, pytest, existing `make` quality targets.
+
+---
+
+## Task 1: Add Artifact Metadata Test
+
+**Files:**
+
+- Modify: `src/tests/test_metrics_modes.py`
+- Modify: `src/check_models.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test after `test_finalize_execution_logs_configured_log_and_env_paths` in `src/tests/test_metrics_modes.py`:
+
+```python
+def test_report_generation_uses_single_artifact_plan(
+    tmp_path: Path,
+) -> None:
+    """Report generation should expose one ordered artifact plan for jobs and logs."""
+    args = argparse.Namespace(
+        output_html=tmp_path / "report.html",
+        output_markdown=tmp_path / "report.md",
+        output_gallery_markdown=tmp_path / "gallery.md",
+        output_review=tmp_path / "review.md",
+        output_tsv=tmp_path / "report.tsv",
+        output_jsonl=tmp_path / "report.jsonl",
+    )
+    inputs = check_models.ReportGenerationInputs(
+        args=args,
+        results=[],
+        library_versions={"mlx": "0.0.0"},
+        prompt="prompt",
+        metadata=None,
+        overall_time=1.0,
+        image_path=None,
+        system_info={},
+        report_context=check_models._build_report_render_context(results=[], prompt="prompt"),
+        jsonl_output_path=args.output_jsonl.resolve(),
+        log_output_path=(tmp_path / "check_models.log").resolve(),
+        env_output_path=(tmp_path / "environment.log").resolve(),
+        review_output_path=args.output_review.resolve(),
+        runtime_fingerprint={},
+    )
+
+    artifacts = check_models._build_report_artifacts(inputs)
+
+    assert [artifact.key for artifact in artifacts] == [
+        "html",
+        "markdown",
+        "markdown_gallery",
+        "review",
+        "tsv",
+        "jsonl",
+    ]
+    assert [artifact.label.strip() for artifact in artifacts] == [
+        "HTML Report:",
+        "Markdown Report:",
+        "Gallery Report:",
+        "Review Report:",
+        "TSV Report:",
+        "JSONL Report:",
+    ]
+    assert all(artifact.path.is_absolute() for artifact in artifacts)
+    assert all(artifact.job is not None for artifact in artifacts)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py::test_report_generation_uses_single_artifact_plan -q
+```
+
+Expected: FAIL because `_build_report_artifacts` does not exist.
+
+- [ ] **Step 3: Implement artifact metadata**
+
+In `src/check_models.py`, add this dataclass near `ReportGenerationInputs`:
+
+```python
+@dataclass(frozen=True)
+class ReportArtifact:
+    """A generated artifact path plus its optional generation job."""
+
+    key: str
+    label: str
+    path: Path
+    job: Callable[[], None] | None = None
+```
+
+Add `_build_report_artifacts(inputs: ReportGenerationInputs) -> tuple[ReportArtifact, ...]` above `_generate_reports_and_log_outputs`. It should resolve paths once, build the six report jobs in order, and return `ReportArtifact` entries for HTML, Markdown, gallery, review, TSV, and JSONL.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py::test_report_generation_uses_single_artifact_plan -q
+```
+
+Expected: PASS.
+
+## Task 2: Refactor Report Generation
+
+**Files:**
+
+- Modify: `src/check_models.py`
+- Modify: `src/tests/test_metrics_modes.py`
+
+- [ ] **Step 1: Write the failing integration-style test**
+
+Extend `test_finalize_execution_logs_configured_log_and_env_paths` so the captured messages are asserted in this order:
+
+```python
+artifact_positions = [
+    next(i for i, msg in enumerate(messages) if "HTML Report:" in msg),
+    next(i for i, msg in enumerate(messages) if "Markdown Report:" in msg),
+    next(i for i, msg in enumerate(messages) if "Gallery Report:" in msg),
+    next(i for i, msg in enumerate(messages) if "Review Report:" in msg),
+    next(i for i, msg in enumerate(messages) if "TSV Report:" in msg),
+    next(i for i, msg in enumerate(messages) if "JSONL Report:" in msg),
+]
+assert artifact_positions == sorted(artifact_positions)
+```
+
+- [ ] **Step 2: Run test to verify it fails if labels/order are not unified**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py::test_finalize_execution_logs_configured_log_and_env_paths -q
+```
+
+Expected before implementation: FAIL if old label spacing or order does not match the unified artifact list.
+
+- [ ] **Step 3: Use artifact metadata in `_generate_reports_and_log_outputs`**
+
+Replace the local `report_jobs` tuple and later `report_paths` tuple with:
+
+```python
+artifacts = _build_report_artifacts(inputs)
+```
+
+Loop over `artifacts` for jobs:
+
+```python
+for artifact in artifacts:
+    if artifact.job is None:
+        continue
+    try:
+        artifact.job()
+    except (OSError, ValueError) as err:
+        logger.exception("Failed to generate %s report.", artifact.key)
+        _write_report_failure_jsonl(
+            filename=inputs.jsonl_output_path,
+            failed_report=artifact.key,
+            error=err,
+        )
+```
+
+Loop over `artifacts` for success logging:
+
+```python
+for artifact in artifacts:
+    log_file_path(artifact.path, label=artifact.label)
+```
+
+Keep log/env logging after report artifact logging.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py::test_report_generation_uses_single_artifact_plan src/tests/test_metrics_modes.py::test_finalize_execution_logs_configured_log_and_env_paths -q
+```
+
+Expected: PASS.
+
+## Task 3: Centralize Finalization Paths
+
+**Files:**
+
+- Modify: `src/check_models.py`
+- Modify: `src/tests/test_metrics_modes.py`
+
+- [ ] **Step 1: Tighten the pruning test**
+
+Keep `test_finalize_execution_prunes_canonical_repro_bundle_dir`, and add an assertion that `_clean_stale_toplevel_reports` receives resolved output/report directories:
+
+```python
+patch("check_models._clean_stale_toplevel_reports", return_value=0) as clean_stale_reports,
+```
+
+After `finalize_execution(...)`, assert:
+
+```python
+clean_stale_reports.assert_called_once_with(tmp_path, reports_dir)
+```
+
+- [ ] **Step 2: Run test to verify current behavior**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py::test_finalize_execution_prunes_canonical_repro_bundle_dir -q
+```
+
+Expected: PASS or FAIL depending on current path object resolution. If it passes, keep it as regression coverage for the refactor.
+
+- [ ] **Step 3: Refactor resolved path setup**
+
+In `finalize_execution`, compute these once:
+
+```python
+html_output_path = args.output_html.resolve()
+markdown_output_path = args.output_markdown.resolve()
+gallery_output_path = args.output_gallery_markdown.resolve()
+review_output_path = args.output_review.resolve()
+tsv_output_path = args.output_tsv.resolve()
+jsonl_output_path = args.output_jsonl.resolve()
+diagnostics_path = args.output_diagnostics.resolve()
+log_output_path = args.output_log.resolve()
+env_output_path = args.output_env.resolve()
+```
+
+Create directories from one tuple of resolved output paths, pass the resolved review/log/env/jsonl paths into `ReportGenerationInputs`, and use `diagnostics_path.parent.parent` for repro pruning as before.
+
+- [ ] **Step 4: Run focused finalization tests**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py::test_finalize_execution_logs_configured_log_and_env_paths src/tests/test_metrics_modes.py::test_finalize_execution_prunes_canonical_repro_bundle_dir -q
+```
+
+Expected: PASS.
+
+## Task 4: Docs and Verification
+
+**Files:**
+
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update changelog**
+
+Add an `[Unreleased]` bullet:
+
+```markdown
+- Streamlined report finalization by driving report generation and artifact
+  logging from one internal artifact list, reducing duplicated output-path
+  handling without changing report formats.
+```
+
+- [ ] **Step 2: Run focused report tests**
+
+Run:
+
+```bash
+conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py src/tests/test_report_generation.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full project gate**
+
+Run:
+
+```bash
+make quality
+```
+
+Expected: PASS. If it fails on the known environment `datasets`/`fsspec` mismatch before tests begin, report that separately and run the narrower test suite as evidence.

--- a/docs/superpowers/specs/2026-05-10-report-finalization-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-10-report-finalization-cleanup-design.md
@@ -1,0 +1,77 @@
+# Report Finalization Cleanup Design
+
+## Goal
+
+Streamline the report-generation and finalization path in `src/check_models.py` by consolidating report artifact metadata, resolving output paths once, and making finalization easier to read and test without changing the core benchmark behavior.
+
+## Scope
+
+This cleanup covers the code that runs after model processing has produced `PerformanceResult` values. It includes report generation, report path logging, history/diagnostics setup, stale-report cleanup, and tests/docs for those behaviors.
+
+This cleanup does not split `src/check_models.py`, rewrite the report renderers, change model execution, change CLI flags, or remove production output artifacts from version control.
+
+## Architecture
+
+Keep the existing single-file monolith, but introduce a small internal data structure for generated artifacts. Each artifact entry should describe the report key, resolved path, user-facing label, and callable used to generate it when applicable. Finalization will build this artifact list once, ensure parent directories exist, run jobs in order, and log generated paths from the same source of truth.
+
+The data-driven structure should remain private to the report/finalization section. It should use existing dataclasses and type aliases where possible and avoid a larger abstraction than the cleanup needs.
+
+## Components
+
+- `ReportGenerationInputs`: keep as the main finalization payload, but prefer resolved paths on it where it already has dedicated fields.
+- New private artifact metadata type: represent each generated report/log artifact with a concise typed container.
+- `_generate_reports_and_log_outputs`: replace parallel tuples for jobs and labels with one artifact list.
+- `finalize_execution`: reduce repeated `.resolve()` calls, centralize output directory creation, and keep history/diagnostics sequencing intact.
+- Existing report generators: keep their public signatures and rendering behavior stable unless a small wording/order cleanup is needed.
+
+## Data Flow
+
+1. `finalize_execution` computes system info, runtime fingerprint, report context, and resolved output paths.
+2. `finalize_execution` creates output directories for all report files that will be written.
+3. `_generate_reports_and_log_outputs` receives resolved paths and builds the artifact list.
+4. Each report job runs in a deterministic order: HTML, Markdown, gallery Markdown, review Markdown, TSV, JSONL.
+5. Report failures still append a JSONL failure record for individual report failures where that behavior already exists.
+6. Success logging lists generated report paths, log path, and environment path using artifact metadata instead of a second hard-coded tuple.
+7. History append, diagnostics generation, repro-bundle pruning, and stale top-level report cleanup keep their existing order.
+
+## Error Handling
+
+Report generation should preserve the existing fail-soft behavior: individual HTML/Markdown/gallery/review failures are logged and recorded to JSONL without preventing later artifacts from attempting to generate. TSV and JSONL generation should continue to be handled by the surrounding report-generation error guard.
+
+Path creation failures should still surface through the existing report/finalization exception logging rather than being silently ignored.
+
+## Output/Workflow Changes
+
+Small user-facing cleanup is acceptable:
+
+- Report artifact logging may be reordered or relabeled for consistency.
+- Log labels should use one consistent alignment style.
+- No report content section should be removed.
+- No CLI flag or default path should change in this pass.
+
+## Tests
+
+Update existing tests only:
+
+- `src/tests/test_metrics_modes.py`: cover configured log/env path logging and pruning behavior after path resolution changes.
+- `src/tests/test_report_generation.py`: cover report generation with supplied report context and artifact-link behavior if labels/order change.
+- Run focused tests for report/finalization changes before the full quality gate.
+
+Expected verification commands:
+
+```bash
+make test
+make quality
+```
+
+## Documentation
+
+Update `CHANGELOG.md` under `[Unreleased]` with the refactor. Update `src/README.md` or `docs/IMPLEMENTATION_GUIDE.md` only if user-facing report artifact labels or workflow wording changes.
+
+## Non-Goals
+
+- No broad CLI parser restructuring.
+- No model execution refactor.
+- No generated artifact git policy change.
+- No standalone test scripts.
+- No new runtime dependency.

--- a/src/check_models.py
+++ b/src/check_models.py
@@ -1178,10 +1178,24 @@ class DiagnosticsArtifacts:
 
 
 @dataclass(frozen=True)
+class ReportOutputPaths:
+    """Resolved final report and log output paths."""
+
+    html: Path
+    markdown: Path
+    gallery_markdown: Path
+    review: Path
+    tsv: Path
+    jsonl: Path
+    diagnostics: Path
+    log: Path
+    environment: Path
+
+
+@dataclass(frozen=True)
 class ReportGenerationInputs:
     """Inputs required to generate final report artifacts and log their paths."""
 
-    args: argparse.Namespace
     results: list[PerformanceResult]
     library_versions: LibraryVersionDict
     prompt: str
@@ -1190,11 +1204,18 @@ class ReportGenerationInputs:
     image_path: Path | None
     system_info: dict[str, str]
     report_context: ReportRenderContext
-    jsonl_output_path: Path
-    log_output_path: Path
-    env_output_path: Path
-    review_output_path: Path
+    output_paths: ReportOutputPaths
     runtime_fingerprint: dict[str, RuntimeProbeResult] | None = None
+
+
+@dataclass(frozen=True)
+class ReportArtifact:
+    """A generated artifact path plus its optional generation job."""
+
+    key: str
+    label: str
+    path: Path
+    job: Callable[[], None] | None = None
 
 
 class ChatTemplateKwargs(TypedDict, total=False):
@@ -22891,18 +22912,33 @@ def _write_environment_failure_diagnostics(
         log_file_path(diagnostics_path, label="   Diagnostics:  ")
 
 
-def _generate_reports_and_log_outputs(
-    inputs: ReportGenerationInputs,
-) -> None:
-    """Generate reports and log the emitted artifact paths."""
-    gallery_output_path = inputs.args.output_gallery_markdown.resolve()
-    review_output_path = inputs.review_output_path
-    report_jobs: tuple[tuple[str, Callable[[], None]], ...] = (
-        (
-            "html",
-            lambda: generate_html_report(
+def _resolve_report_output_paths(args: argparse.Namespace) -> ReportOutputPaths:
+    """Resolve all final report/log output paths once for finalization."""
+    return ReportOutputPaths(
+        html=args.output_html.resolve(),
+        markdown=args.output_markdown.resolve(),
+        gallery_markdown=args.output_gallery_markdown.resolve(),
+        review=args.output_review.resolve(),
+        tsv=args.output_tsv.resolve(),
+        jsonl=args.output_jsonl.resolve(),
+        diagnostics=args.output_diagnostics.resolve(),
+        log=args.output_log.resolve(),
+        environment=args.output_env.resolve(),
+    )
+
+
+def _build_report_artifacts(inputs: ReportGenerationInputs) -> tuple[ReportArtifact, ...]:
+    """Build the ordered final report artifact plan."""
+    output_paths = inputs.output_paths
+
+    return (
+        ReportArtifact(
+            key="html",
+            label="   HTML Report:     ",
+            path=output_paths.html,
+            job=lambda: generate_html_report(
                 results=inputs.results,
-                filename=inputs.args.output_html,
+                filename=output_paths.html,
                 versions=inputs.library_versions,
                 prompt=inputs.prompt,
                 total_runtime_seconds=inputs.overall_time,
@@ -22910,85 +22946,101 @@ def _generate_reports_and_log_outputs(
                 report_context=inputs.report_context,
             ),
         ),
-        (
-            "markdown",
-            lambda: generate_markdown_report(
+        ReportArtifact(
+            key="markdown",
+            label="   Markdown Report: ",
+            path=output_paths.markdown,
+            job=lambda: generate_markdown_report(
                 results=inputs.results,
-                filename=inputs.args.output_markdown,
+                filename=output_paths.markdown,
                 versions=inputs.library_versions,
                 prompt=inputs.prompt,
                 total_runtime_seconds=inputs.overall_time,
                 report_context=inputs.report_context,
-                gallery_filename=gallery_output_path,
-                review_filename=review_output_path,
-                log_filename=inputs.log_output_path,
+                gallery_filename=output_paths.gallery_markdown,
+                review_filename=output_paths.review,
+                log_filename=output_paths.log,
             ),
         ),
-        (
-            "markdown_gallery",
-            lambda: generate_markdown_gallery_report(
+        ReportArtifact(
+            key="markdown_gallery",
+            label="   Gallery Report:  ",
+            path=output_paths.gallery_markdown,
+            job=lambda: generate_markdown_gallery_report(
                 results=inputs.results,
-                filename=gallery_output_path,
+                filename=output_paths.gallery_markdown,
                 prompt=inputs.prompt,
                 metadata=inputs.metadata,
                 report_context=inputs.report_context,
             ),
         ),
-        (
-            "review",
-            lambda: generate_review_report(
+        ReportArtifact(
+            key="review",
+            label="   Review Report:   ",
+            path=output_paths.review,
+            job=lambda: generate_review_report(
                 results=inputs.results,
-                filename=review_output_path,
+                filename=output_paths.review,
                 prompt=inputs.prompt,
                 report_context=inputs.report_context,
-                log_filename=inputs.log_output_path,
-                gallery_filename=gallery_output_path,
+                log_filename=output_paths.log,
+                gallery_filename=output_paths.gallery_markdown,
+            ),
+        ),
+        ReportArtifact(
+            key="tsv",
+            label="   TSV Report:      ",
+            path=output_paths.tsv,
+            job=lambda: generate_tsv_report(
+                results=inputs.results,
+                filename=output_paths.tsv,
+                report_context=inputs.report_context,
+            ),
+        ),
+        ReportArtifact(
+            key="jsonl",
+            label="   JSONL Report:    ",
+            path=output_paths.jsonl,
+            job=lambda: save_jsonl_report(
+                inputs.results,
+                output_paths.jsonl,
+                prompt=inputs.prompt,
+                system_info=inputs.system_info,
+                library_versions=inputs.library_versions,
+                runtime_fingerprint=inputs.runtime_fingerprint,
             ),
         ),
     )
 
+
+def _generate_reports_and_log_outputs(
+    inputs: ReportGenerationInputs,
+) -> None:
+    """Generate reports and log the emitted artifact paths."""
+    artifacts = _build_report_artifacts(inputs)
+
     try:
-        for report_name, report_job in report_jobs:
+        for artifact in artifacts:
+            if artifact.job is None:
+                continue
             try:
-                report_job()
+                artifact.job()
             except (OSError, ValueError) as err:
-                logger.exception("Failed to generate %s report.", report_name)
+                logger.exception("Failed to generate %s report.", artifact.key)
                 _write_report_failure_jsonl(
-                    filename=inputs.jsonl_output_path,
-                    failed_report=report_name,
+                    filename=inputs.output_paths.jsonl,
+                    failed_report=artifact.key,
                     error=err,
                 )
 
-        generate_tsv_report(
-            results=inputs.results,
-            filename=inputs.args.output_tsv,
-            report_context=inputs.report_context,
-        )
-        save_jsonl_report(
-            inputs.results,
-            inputs.args.output_jsonl,
-            prompt=inputs.prompt,
-            system_info=inputs.system_info,
-            library_versions=inputs.library_versions,
-            runtime_fingerprint=inputs.runtime_fingerprint,
-        )
-
         logger.info("")
         log_success("Reports successfully generated:", prefix="📊")
-        report_paths = (
-            (inputs.args.output_html, "   HTML Report:"),
-            (inputs.args.output_markdown, "   Markdown Report:"),
-            (inputs.args.output_gallery_markdown, "   Gallery Report: "),
-            (inputs.args.output_review, "   Review Report:  "),
-            (inputs.args.output_tsv, "   TSV Report:   "),
-            (inputs.args.output_jsonl, "   JSONL Report: "),
-        )
-        for path, label in report_paths:
-            log_file_path(path, label=label)
+        for artifact in artifacts:
+            log_file_path(artifact.path, label=artifact.label)
 
-        log_file_path(inputs.log_output_path, label="   Log File:")
-        if inputs.env_output_path.exists():
-            log_file_path(inputs.env_output_path, label="   Environment:")
+        log_file_path(inputs.output_paths.log, label="   Log File:")
+        if inputs.output_paths.environment.exists():
+            log_file_path(inputs.output_paths.environment, label="   Environment:")
     except (OSError, ValueError):
         logger.exception("Failed to generate reports.")
 
@@ -23236,27 +23288,22 @@ def finalize_execution(
         )
 
         # Prepare output paths
-        tsv_output_path: Path = args.output_tsv.resolve()
-        jsonl_output_path: Path = args.output_jsonl.resolve()
-        diagnostics_path: Path = args.output_diagnostics.resolve()
-        log_output_path: Path = args.output_log.resolve()
-        env_output_path: Path = args.output_env.resolve()
-        history_path = _history_path_for_jsonl(jsonl_output_path)
+        output_paths = _resolve_report_output_paths(args)
+        history_path = _history_path_for_jsonl(output_paths.jsonl)
         previous_history = _load_latest_history_record(history_path)
 
         for output_path in (
-            args.output_html.resolve(),
-            args.output_markdown.resolve(),
-            args.output_gallery_markdown.resolve(),
-            args.output_review.resolve(),
-            tsv_output_path,
-            jsonl_output_path,
+            output_paths.html,
+            output_paths.markdown,
+            output_paths.gallery_markdown,
+            output_paths.review,
+            output_paths.tsv,
+            output_paths.jsonl,
         ):
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
         _generate_reports_and_log_outputs(
             ReportGenerationInputs(
-                args=args,
                 results=results,
                 library_versions=library_versions,
                 prompt=prompt,
@@ -23265,10 +23312,7 @@ def finalize_execution(
                 image_path=image_path,
                 system_info=system_info,
                 report_context=report_context,
-                jsonl_output_path=jsonl_output_path,
-                log_output_path=log_output_path,
-                env_output_path=env_output_path,
-                review_output_path=args.output_review.resolve(),
+                output_paths=output_paths,
                 runtime_fingerprint=runtime_fingerprint,
             ),
         )
@@ -23297,26 +23341,26 @@ def finalize_execution(
             system_info=system_info,
             prompt=prompt,
             image_path=image_path,
-            diagnostics_path=diagnostics_path,
+            diagnostics_path=output_paths.diagnostics,
             history_path=history_path,
             previous_history=previous_history,
             current_history=current_history,
         )
         _log_maintainer_summary(
             artifacts=diagnostics_artifacts,
-            diagnostics_path=diagnostics_path,
+            diagnostics_path=output_paths.diagnostics,
         )
 
         # Prune old repro bundles
         prune_days = getattr(args, "prune_repro_days", 90)
         if prune_days > 0:
-            repro_dir = diagnostics_path.parent.parent / "repro_bundles"
+            repro_dir = output_paths.diagnostics.parent.parent / "repro_bundles"
             pruned = _prune_repro_bundles(repro_dir, prune_days)
             if pruned:
                 logger.info("Pruned %d repro bundle(s) older than %d days.", pruned, prune_days)
 
         # Remove stale top-level report copies superseded by reports/ subdirectory
-        reports_dir = diagnostics_path.parent
+        reports_dir = output_paths.diagnostics.parent
         output_dir = reports_dir.parent
         stale_removed = _clean_stale_toplevel_reports(output_dir, reports_dir)
         if stale_removed:

--- a/src/tests/test_metrics_modes.py
+++ b/src/tests/test_metrics_modes.py
@@ -789,6 +789,63 @@ def test_finalize_execution_logs_configured_log_and_env_paths(
     assert any(str(custom_env.resolve()) in msg for msg in messages)
     assert any(str(args.output_gallery_markdown.resolve()) in msg for msg in messages)
     assert any(str(args.output_review.resolve()) in msg for msg in messages)
+    artifact_positions = [
+        next(i for i, msg in enumerate(messages) if "HTML Report:" in msg),
+        next(i for i, msg in enumerate(messages) if "Markdown Report:" in msg),
+        next(i for i, msg in enumerate(messages) if "Gallery Report:" in msg),
+        next(i for i, msg in enumerate(messages) if "Review Report:" in msg),
+        next(i for i, msg in enumerate(messages) if "TSV Report:" in msg),
+        next(i for i, msg in enumerate(messages) if "JSONL Report:" in msg),
+    ]
+    assert artifact_positions == sorted(artifact_positions)
+
+
+def test_report_generation_uses_single_artifact_plan(tmp_path: Path) -> None:
+    """Report generation should expose one ordered artifact plan for jobs and logs."""
+    args = argparse.Namespace(
+        output_html=tmp_path / "report.html",
+        output_markdown=tmp_path / "report.md",
+        output_gallery_markdown=tmp_path / "gallery.md",
+        output_review=tmp_path / "review.md",
+        output_tsv=tmp_path / "report.tsv",
+        output_jsonl=tmp_path / "report.jsonl",
+        output_diagnostics=tmp_path / "diagnostics.md",
+        output_log=tmp_path / "check_models.log",
+        output_env=tmp_path / "environment.log",
+    )
+    inputs = check_models.ReportGenerationInputs(
+        results=[],
+        library_versions={"mlx": "0.0.0"},
+        prompt="prompt",
+        metadata=None,
+        overall_time=1.0,
+        image_path=None,
+        system_info={},
+        report_context=check_models._build_report_render_context(results=[], prompt="prompt"),
+        output_paths=check_models._resolve_report_output_paths(args),
+        runtime_fingerprint={},
+    )
+
+    artifacts = check_models._build_report_artifacts(inputs)
+
+    assert [artifact.key for artifact in artifacts] == [
+        "html",
+        "markdown",
+        "markdown_gallery",
+        "review",
+        "tsv",
+        "jsonl",
+    ]
+    assert [artifact.label.strip() for artifact in artifacts] == [
+        "HTML Report:",
+        "Markdown Report:",
+        "Gallery Report:",
+        "Review Report:",
+        "TSV Report:",
+        "JSONL Report:",
+    ]
+    assert all(artifact.path.is_absolute() for artifact in artifacts)
+    assert all(artifact.job is not None for artifact in artifacts)
 
 
 def test_finalize_execution_prunes_canonical_repro_bundle_dir(tmp_path: Path) -> None:
@@ -835,6 +892,7 @@ def test_finalize_execution_prunes_canonical_repro_bundle_dir(tmp_path: Path) ->
         patch("check_models.generate_diagnostics_report", return_value=False),
         patch("check_models._log_history_comparison"),
         patch("check_models._prune_repro_bundles", return_value=0) as prune_repro_bundles,
+        patch("check_models._clean_stale_toplevel_reports", return_value=0) as clean_stale_reports,
     ):
         finalize_execution(
             args=args,
@@ -847,3 +905,4 @@ def test_finalize_execution_prunes_canonical_repro_bundle_dir(tmp_path: Path) ->
         )
 
     prune_repro_bundles.assert_called_once_with(tmp_path / "repro_bundles", 90)
+    clean_stale_reports.assert_called_once_with(tmp_path, reports_dir)


### PR DESCRIPTION
## Summary

- Consolidates final report outputs into a `ReportOutputPaths` bundle and one ordered `ReportArtifact` list.
- Uses the artifact list for report generation and success-path artifact logging, removing duplicated path/job tuples.
- Adds focused coverage for artifact ordering, resolved cleanup paths, and documents the approved design/plan.

## Test Plan

- `conda run -n mlx-vlm pytest src/tests/test_metrics_modes.py src/tests/test_report_generation.py -q`
- `make quality`
- Pre-push fast quality checks

## Notes

Report formats and CLI defaults are intentionally unchanged.