### PR TITLE
Fix run regression ownership and issue reporting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ is a setup failure, not a product regression.
 
 | File | Purpose | Size |
 | ------ | --------- | ------ |
-| `src/check_models.py` | **Single-file CLI monolith** (~17,200 lines). All logic lives here. | ★ primary edit target |
+| `src/check_models.py` | **Single-file CLI monolith** (~18,000 lines). All logic lives here. | ★ primary edit target |
 | `src/check_models_data/quality_config.yaml` | Runtime thresholds loaded by `load_quality_config()` | Edit thresholds here, not in Python |
 | `src/pyproject.toml` | Packaging, dependencies, tool config (ruff, mypy, pytest) | Update when adding imports |
 | `src/tests/conftest.py` | Shared fixtures: `test_image`, `minimal_test_image`, `realistic_test_image`, `folder_with_images`, etc. | Use existing fixtures |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Make run issue summaries more actionable by sorting each execution table by
+  likely output impact, spelling out structured failures when no observation is
+  available, recording remote-code and producer provenance, and ignoring generated
+  `src/output/` changes when calculating producer dirtiness. Detailed crash drafts
+  now keep only runtime-relevant environment facts and link to the complete
+  repository environment artifact.
+- Record out-of-range catalogue title/keyword counts and duplicate keywords as
+  structured repairable caveats, and recognise configured turn, message, and
+  utterance delimiters as visible role-boundary tokens.
 - Make paste-ready crash reproductions self-contained when the exact input image
   has a recorded public HTTP(S) source: include download and SHA-256 verification
   commands plus a native mlx-vlm invocation with the exact prompt. For unpublished
@@ -96,6 +105,12 @@ Notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Accept callable custom mlx-vlm processors that support images without exposing
+  Transformers' optional `image_processor` attribute, and retry connectivity-only
+  Hub load failures from a matching resolved local snapshot when downloads were
+  not forced.
+- Exclude ignored `.worktrees/` checkouts from suppression and Markdown audits so
+  an isolated upstream checkout cannot contaminate check_models quality results.
 - Preserve `ObservationCode` key typing while building diagnostics counts so
   Pylance agrees with the other supported type checkers at the label-rendering
   boundary.

--- a/docs/superpowers/plans/2026-08-02-run-regression-ownership.md
+++ b/docs/superpowers/plans/2026-08-02-run-regression-ownership.md
@@ -1,0 +1,300 @@
+# Run Regression Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct the harness defects exposed by the 2 August run and submit the independently reproduced Idefics3 stopping-token fix to `mlx-vlm`.
+
+**Architecture:** Keep all harness behaviour in the existing `src/check_models.py` monolith and extend its typed quality/report records rather than adding a parallel report pipeline. Isolate the upstream fix in a separate `mlx-vlm` worktree and PR; do not move model-capability observations upstream without a native runtime reproduction.
+
+**Tech Stack:** Python 3.13, mlx-vlm, Transformers tokenizers, Hugging Face cache metadata, pytest, Ruff, mypy, ty, Pyrefly, markdownlint, GitHub CLI.
+
+## Global Constraints
+
+- Activate the `mlx-vlm` Conda environment before every Python or Make command.
+- Keep `src/check_models.py` as the intentional single-file monolith.
+- Add tests only to existing `src/tests/test_*.py` files.
+- Do not rewrite the committed `src/output/` snapshot.
+- Preserve exact generated model text in machine and evidence artifacts.
+- Apply only safe Ruff fixes routinely; inspect every unsafe fix before accepting it.
+- Never use `uv` in either repository.
+
+---
+
+### Task 1: Accept valid custom processors and recover cached loads
+
+**Files:**
+
+- Modify: `src/tests/test_process_image_mock.py`
+- Modify: `src/check_models.py` near `_load_model`, `_resolve_model_snapshot_path`, and `_run_model_preflight_validators`
+
+**Interfaces:**
+
+- Consumes: `ProcessImageParams`, `_has_external_connectivity_signal(...)`, and `_resolve_model_snapshot_path(...)`
+- Produces: a load retry using a matching local snapshot after connectivity-only failure
+- Produces: processor preflight based on callable/tokenizer interfaces, not an `image_processor` attribute
+
+- [ ] **Step 1: Write failing processor and cache-retry tests**
+
+Add tests that prove a callable Step-like processor with `tokenizer` and
+`detokenizer` passes preflight without `image_processor`, and that `_load_model`
+retries a connection-reset failure with a resolved local snapshot but does not
+retry a model/config error or a mismatched requested revision.
+
+```python
+class _FakeStepProcessor(_FakeProcessor):
+    def __call__(self, *_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
+
+def test_preflight_accepts_custom_image_processor_without_attribute() -> None:
+    check_models._run_model_preflight_validators(
+        model_identifier="org/step",
+        processor=_FakeStepProcessor(),
+        config={"model_type": "step3p7"},
+    )
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+pytest src/tests/test_process_image_mock.py -k "preflight_accepts or load_model_retries" -q
+```
+
+Expected: the Step-like processor is rejected and the local retry is absent.
+
+- [ ] **Step 3: Implement the minimal runtime fixes**
+
+Remove the `image_processor is None` rejection. In `_load_model`, keep the first
+Hub-ID call unchanged; on a connectivity exception only, resolve a local
+snapshot, verify any requested immutable revision, and call `load()` once with
+the snapshot path. Preserve `--force-download` by not falling back when it is
+set.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the focused tests above plus the existing process-image mock file.
+
+---
+
+### Task 2: Record catalogue constraints and escaped turn boundaries
+
+**Files:**
+
+- Modify: `src/tests/test_quality_analysis.py`
+- Modify: `src/tests/test_jsonl_output.py`
+- Modify: `src/check_models.py` near `ObservationCode`, `GenerationQualityAnalysis`, `_collect_prompt_quality_signals`, `_configured_role_boundaries`, and `_observation_details`
+
+**Interfaces:**
+
+- Produces: `catalog_constraint_violation` in `ObservationCode`
+- Produces: `title_word_count`, `keyword_count`, and `duplicate_keywords` detail fields
+- Extends: `role_boundary_token_present` to configured `turn`, `message`, and `utterance` tokens
+
+- [ ] **Step 1: Write failing literal contract tests**
+
+Cover a four-word title, nineteen keywords, duplicate case-insensitive keywords,
+a compliant result, and an Idefics-style `<end_of_utterance>` suffix. Assert
+that only the defective results receive the new caveat and exact details.
+
+```python
+assert check_models._assess_result(result).usability == "usable_with_caveats"
+assert "catalog_constraint_violation" in assessment.observations
+assert result.quality_analysis.duplicate_keywords == ["halesworth"]
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+pytest src/tests/test_quality_analysis.py src/tests/test_jsonl_output.py -k "constraint or utterance" -q
+```
+
+- [ ] **Step 3: Implement mechanical validation**
+
+Parse the already-recognised sections once, count title words with the existing
+word-token convention, split keywords with `_split_catalog_keywords`, and
+deduplicate by case-folded collapsed whitespace. Run these checks only when the
+prompt requests the catalogue contract and all three sections are present.
+
+Extend `_configured_role_boundaries` to match configured token names containing
+`user`, `assistant`, `system`, `turn`, `message`, or `utterance` while preserving
+the existing leading-assistant exemption.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the two complete focused test files.
+
+---
+
+### Task 3: Make the issue summary actionable and provenance-complete
+
+**Files:**
+
+- Modify: `src/tests/test_report_generation.py`
+- Modify: `src/tests/test_jsonl_output.py`
+- Modify: `src/check_models.py` near `RunIssueSummarySource`, `_load_run_issue_enrichment`, `_human_observation_labels`, `_run_issue_summary_surfaced_sections`, `_run_issue_summary_context_section`, and `_collect_check_models_provenance`
+
+**Interfaces:**
+
+- Produces: a readable catalogue-constraint label built from structured details
+- Produces: `_run_issue_summary_failure_label(...) -> str`
+- Extends: `RunIssueSummarySource` with optional producer provenance
+
+- [ ] **Step 1: Write failing report/provenance tests**
+
+Use hand-authored schema-2.0 fixtures to assert:
+
+- a network-reset indeterminate row says `Network connection reset during model loading`;
+- repeated/empty/truncated rows sort ahead of missing-field/count caveats;
+- run context includes remote-code trust and producer version/revision/dirty;
+- generated-output-only Git status is clean, while a source edit remains dirty;
+- the summary states that `main` links are mutable and names the producer revision.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+pytest src/tests/test_report_generation.py src/tests/test_jsonl_output.py -k "failure_reason or severity or provenance or mutable" -q
+```
+
+- [ ] **Step 3: Implement the report changes**
+
+Load and narrow `producer` from run JSON. Use structured failure stage, phase,
+code, exception type, and message to build a bounded plain-language fallback
+when observations are empty. Sort rows by the index of their first display
+priority, then usability and case-folded model name.
+
+Call Git status with pathspec exclusions for tracked `src/output/` files when
+computing producer dirtiness. Keep all other tracked changes significant.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run both complete focused files and markdownlint against a temporary rendered
+summary.
+
+---
+
+### Task 4: Reduce detailed crash-report environment noise
+
+**Files:**
+
+- Modify: `src/tests/test_report_generation.py`
+- Modify: `src/check_models.py` in the direct issue-report environment builder
+
+**Interfaces:**
+
+- Consumes: existing component provenance and complete environment artifact path
+- Produces: a bounded relevant-component table plus a canonical link to full environment evidence
+
+- [ ] **Step 1: Add a failing direct-issue rendering test**
+
+Assert that `mlx-vlm`, `mlx`, `transformers`, `tokenizers`, Python, macOS, chip,
+and check_models revision remain visible; unrelated compiler/SDK fingerprints do
+not; and the full environment artifact is linked.
+
+- [ ] **Step 2: Verify RED**
+
+Run the single direct-issue test.
+
+- [ ] **Step 3: Narrow the rendered component subset and add the evidence link**
+
+Reuse existing typed report blocks and canonical issue-link helpers. Do not
+remove facts from `environment.log`, `run.json`, or diagnostics.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the complete report-generation test file.
+
+---
+
+### Task 5: Implement and test the upstream Idefics3 EOS fix
+
+**Files:**
+
+- Modify in an isolated `mlx-vlm` worktree: `mlx_vlm/models/idefics3/processing_idefics3.py`
+- Modify in that worktree: `mlx_vlm/tests/test_processors.py`
+
+**Interfaces:**
+
+- Produces: an Idefics3 processor stop-token ID that the shared loader merges into `StoppingCriteria.eos_token_ids`
+
+- [ ] **Step 1: Create the isolated upstream worktree and branch**
+
+Create a `codex/idefics3-end-of-utterance-eos` branch from current upstream
+`main` without modifying the maintainer's existing checkout.
+
+- [ ] **Step 2: Write a failing processor-level test**
+
+Use a fake tokenizer whose existing EOS IDs are `[128001, 128008, 128009]` and
+whose `<end_of_utterance>` ID is `128258`. Assert the effective stopping IDs are:
+
+```python
+[128001, 128008, 128009, 128258]
+```
+
+and that duplicates are not introduced.
+
+- [ ] **Step 3: Verify RED**
+
+Run the narrow upstream processor test with pytest in the same Conda environment.
+
+- [ ] **Step 4: Implement the smallest processor/loader contract**
+
+Expose the processor-specific stop ID and merge it in the shared processor loader
+after tokenizer/model EOS discovery. Preserve order and every configured EOS ID.
+
+- [ ] **Step 5: Verify GREEN and native behaviour**
+
+Run the focused processor tests, upstream formatting/pre-commit on edited files,
+then repeat the cached native Idefics3 command without explicit `--eos-tokens`.
+Expected output contains the three catalogue fields and no
+`<end_of_utterance>`.
+
+- [ ] **Step 6: Commit, push, and open the upstream PR**
+
+Use a factual PR body containing the exact revision, native before/control
+outputs, environment, and focused test command. Do not file a separate issue
+unless maintainers require one.
+
+---
+
+### Task 6: Documentation, full verification, and check_models PR
+
+**Files:**
+
+- Modify: `CHANGELOG.md`
+- Modify: `src/README.md` only where report semantics need user documentation
+
+- [ ] **Step 1: Update `[Unreleased]` and user-facing report documentation**
+
+Describe corrected processor compatibility, cache fallback, catalogue caveats,
+escaped turn-token detection, and issue-summary provenance.
+
+- [ ] **Step 2: Run prescribed formatting and lint sequence**
+
+```bash
+make format
+make -C src lint-fix
+make lint
+bash src/tools/run_commit_hygiene.sh
+```
+
+- [ ] **Step 3: Run the full quality gate**
+
+```bash
+make quality
+```
+
+- [ ] **Step 4: Review the final diff and output hygiene**
+
+Confirm `src/output/` is byte-unchanged, no unrelated files changed, every new
+observation has typed JSON detail evidence, and both native ownership claims are
+documented.
+
+- [ ] **Step 5: Commit, push, and open the check_models PR**
+
+The PR body should link the upstream Idefics3 PR and explain why the remaining
+bad outputs are classified as model limitations rather than mlx-vlm defects.

--- a/docs/superpowers/specs/2026-08-02-run-regression-ownership-design.md
+++ b/docs/superpowers/specs/2026-08-02-run-regression-ownership-design.md
@@ -1,0 +1,115 @@
+# Run Regression Ownership and Upstream Fixes Design
+
+## Goal
+
+Turn the 2 August benchmark evidence into narrowly owned fixes: improve
+`check_models` where its assessment or execution policy is wrong, and submit an
+upstream `mlx-vlm` fix only where the same defect reproduces through native
+`mlx-vlm`.
+
+The retained `src/output/` snapshot remains unchanged. New reports will acquire
+the improved behaviour when the maintainer reruns the matrix.
+
+## Evidence and ownership
+
+The current and recent retained runs use the same Transformers 5.14.1,
+tokenizers 0.22.2, model revisions, and materially identical image-generation
+code. The `mlx-vlm` source changes between the immediately preceding and current
+runs affect video fallback only. The new image and assisted metadata prompt are
+therefore the important changed variables, not a Transformers upgrade.
+
+Native isolation establishes these ownership decisions:
+
+- `mlx-community/Step-3.7-Flash-oQ2e` generates a correct caption through native
+  `mlx-vlm`. Its reported processor crash is a `check_models` false positive:
+  `Step3VLProcessor` is callable and supports images without exposing an
+  `image_processor` attribute.
+- `mlx-community/Idefics3-8B-Llama3-bf16` emits a literal
+  `<end_of_utterance>` through native `mlx-vlm`. Configuring that declared token
+  as EOS produces the same answer without the delimiter. This belongs upstream.
+- Both Molmo variants return an immediate empty answer for the long catalogue
+  prompt even after the image is resized, while a short one-sentence prompt on
+  the same resized image succeeds. This is prompt-following capacity, not an
+  image-size or runtime defect.
+- Repetition, missing fields, long thinking traces, and raw GLM/DiffusionGemma
+  protocol markers do not become upstream defects merely because they are poor
+  catalogue answers. They require a smaller native runtime failure before an
+  upstream change is justified.
+
+## `check_models` changes
+
+### Runtime correctness
+
+Processor preflight will require only the interfaces the harness actually uses:
+a callable processor and a resolvable generation tokenizer. It will not require
+the optional `image_processor` attribute. Native `mlx-vlm.generate()` remains
+the authority on whether a processor can consume the supplied image.
+
+When loading a Hub identifier fails solely because of connectivity and a
+resolved local snapshot is available, the harness will retry once with that
+snapshot path. A requested immutable revision must match the snapshot before it
+is used. Non-connectivity failures will not be retried, and `--force-download`
+will preserve its online semantics.
+
+### Catalogue contract observations
+
+For an output with all three catalogue sections, mechanical validation will
+record:
+
+- title word counts outside the requested 5–10 range;
+- keyword counts outside the requested 10–18 range; and
+- duplicate keywords after case-folding and whitespace normalisation.
+
+These are one stable `catalog_constraint_violation` observation with structured
+details. They make a completion `usable_with_caveats`, not unusable, because the
+answer remains straightforward to repair.
+
+Configured special tokens that denote a conversation, message, turn, or
+utterance boundary and remain visible in generated text will be reported as
+`role_boundary_token_present`. Tokenizer-declared wrappers will continue to be
+removed only from the semantic-analysis copy, never from retained exact output.
+
+### Issue-summary ergonomics and provenance
+
+Rows within each execution-status table will be sorted by the most severe human
+observation and then model name. A non-completed result with no observations
+will show a concise failure description, such as `Network connection reset
+during model loading`, rather than `none`.
+
+Run context will include `trust_remote_code` and check_models version, revision,
+and dirty state when available. Producer dirtiness will ignore tracked generated
+files under `src/output/`, so writing a run does not mark its own source tree
+dirty; other tracked changes still do.
+
+Repository links remain canonical GitHub URLs. The summary will make their
+mutable `main`-branch lifecycle explicit and include the producer revision so a
+reader can identify the code used for the run. Creating immutable links to
+freshly generated, not-yet-committed output is intentionally not attempted.
+
+The detailed crash issue will show the dependency subset relevant to a model
+load/generation failure and link to the complete environment artifact instead of
+repeating unrelated SDK/tool fingerprints.
+
+## `mlx-vlm` pull request
+
+The upstream change will teach the Idefics3 processor/loading path to merge the
+processor's `<end_of_utterance>` token ID into its stopping criteria. It must
+preserve every existing EOS token, deduplicate IDs, and stop before detokenizing
+the delimiter. The test will use a small fake tokenizer/processor boundary and
+will not load model weights.
+
+The PR body will include the native reproduction, exact model revision,
+environment versions, expected and actual output, and the confirmed
+`--eos-tokens '<end_of_utterance>'` control result. No issue or PR will be opened
+for observations that remain attributable to model capability.
+
+## Tests and verification
+
+Every production change starts with a focused failing test. `check_models`
+tests use existing test files and temporary output paths. The retained output
+snapshot is not regenerated.
+
+After focused tests, run `make format`, safe Ruff fixes if useful, `make lint`,
+commit hygiene, and `make quality` in the `mlx-vlm` Conda environment. The
+upstream worktree will run its focused processor tests and formatter/pre-commit
+checks before a branch is pushed and a PR is created.

--- a/src/README.md
+++ b/src/README.md
@@ -273,10 +273,12 @@ The tool generates a deliberately small artifact set in `output/` by default:
 - **Run issue summary** (`issues/run_summary.md`): Conditional compact whole-run
   GitHub issue body. It expands crashes with root exceptions and a parameterised
   reproduction command, separates completed, crashed, and indeterminate attempts
-  requiring review into compact tables, counts clean completions, and links to the
-  complete retained evidence without copying full prompts, outputs, tracebacks, or
-  scripts. Its cross-file links always use canonical GitHub repository URLs so they
-  still work when the report is pasted into an issue.
+  requiring review into severity-ordered compact tables, explains structured
+  failures even when no output observation exists, counts clean completions, and
+  records remote-code and producer provenance. It links to complete retained
+  evidence without copying full prompts, outputs, tracebacks, or scripts. Its
+  cross-file links always use canonical GitHub repository URLs so they still work
+  when the report is pasted into an issue.
 - **Index** (`index.md`): Tiny navigation page linking the current-run files and,
   when generated, the run issue summary before individual crash drafts.
 - **Log** (`check_models.log`): Canonical comprehensive run trace, including complete
@@ -285,7 +287,9 @@ The tool generates a deliberately small artifact set in `output/` by default:
 - **History** (`results.history.jsonl`): Append-only raw history for optional
   out-of-band analysis. Current reports do not read it or derive advice from it.
 - **Issue drafts** (`issues/issue_*.md`): Conditional factual drafts, not a standing
-  report surface. Issue drafts are created only for hard actionable crashes.
+  report surface. Issue drafts are created only for hard actionable crashes. Their
+  inline environment table is limited to runtime-relevant components and links to
+  the complete retained `environment.log` inventory.
 
 Regenerate only the compact issue body from an existing retained run, without
 model discovery or inference:
@@ -319,8 +323,8 @@ thinking traces remain factual observations that may need controlled reproductio
 Likewise, tokenizer special-token metadata, tokenizer EOS, explicit `eos_tokens`,
 and configured thinking start/end wrappers are treated as declared protocol.
 Configured conversation-role tokens remain declared rather than “unknown”; when a
-new user/assistant/system boundary occurs inside generated content, its exact token
-is retained as a separate role-boundary observation.
+new user/assistant/system/turn/message/utterance boundary occurs inside generated
+content, its exact token is retained as a separate role-boundary observation.
 Control-wrapper syntax that appears in output without any of those declarations is
 retained as an `unexpected_special_token` observation; no model-name allowlist is
 used.
@@ -329,6 +333,9 @@ retained as an `unexpected_catalog_preamble` observation. Conventional Markdown
 label emphasis such as `**Title:**` and one-to-six-hash headings such as
 `### Title:` are accepted, and authoritative context values are never treated as
 copied instructions merely because a model reuses them.
+When the prompt explicitly requests catalogue ranges and unique keywords, complete
+three-field outputs also record out-of-range title/keyword counts and duplicate
+keywords as repairable caveats rather than unusable results.
 The chooser reports `insufficient sample` when throughput lacks enough generated
 tokens for a meaningful comparison.
 

--- a/src/check_models.py
+++ b/src/check_models.py
@@ -915,6 +915,7 @@ type ObservationCode = Literal[
     "thinking_trace_present",
     "thinking_trace_incomplete",
     "role_boundary_token_present",
+    "catalog_constraint_violation",
     "no_keyword_overlap",
     "draft_returned_unchanged",
 ]
@@ -1077,6 +1078,11 @@ class JsonlObservationDetailsRecord(TypedDict, total=False):
     configured_generation_wrappers: list[str]
     thinking_trace_markers: list[str]
     role_boundary_tokens: list[str]
+    title_word_count: int
+    title_word_range: list[int]
+    keyword_count: int
+    keyword_count_range: list[int]
+    duplicate_keywords: list[str]
     token_cap_reasons: list[str]
     unchanged_draft_fields: list[str]
 
@@ -1120,6 +1126,7 @@ class RunIssueSummarySource:
     image: RunImageRecord | None = None
     generation_settings: tuple[tuple[str, str], ...] = ()
     trust_remote_code: bool | None = None
+    producer: CheckModelsProvenanceRecord | None = None
 
 
 class RunIssueSummaryValidationError(ValueError):
@@ -3420,7 +3427,10 @@ def _configured_role_boundaries(text: str, wrappers: Sequence[str]) -> list[str]
     for token in wrappers:
         token_lower = token.casefold()
         position = text.find(token)
-        if position < 0 or not any(role in token_lower for role in ("user", "assistant", "system")):
+        if position < 0 or not any(
+            boundary in token_lower
+            for boundary in ("user", "assistant", "system", "turn", "message", "utterance")
+        ):
             continue
         if "assistant" not in token_lower or position > leading_start:
             boundaries.append(token)
@@ -3671,6 +3681,23 @@ def _prompt_requests_catalog_contract(prompt: str) -> bool:
     return has_required_labels and (
         "return exactly these three sections" in prompt_lower or "catalog" in prompt_lower
     )
+
+
+def _catalog_requested_range(
+    prompt: str,
+    field: Literal["title", "keyword"],
+) -> tuple[int, int] | None:
+    """Return an explicit numeric range from a prompt line about one field."""
+    for line in prompt.splitlines():
+        if field not in line.casefold():
+            continue
+        match = re.search(r"\b(\d+)\s*[-\u2013]\s*(\d+)\b", line)
+        if match is None:
+            continue
+        lower, upper = (int(match.group(1)), int(match.group(2)))
+        if 0 <= lower <= upper:
+            return lower, upper
+    return None
 
 
 def _missing_catalog_sections(text: str) -> list[str]:
@@ -3934,6 +3961,11 @@ class GenerationQualityAnalysis:
     special_token_wrappers: list[str] = dataclass_field(default_factory=list)
     configured_generation_wrappers: list[str] = dataclass_field(default_factory=list)
     role_boundary_tokens: list[str] = dataclass_field(default_factory=list)
+    title_word_count: int | None = None
+    title_word_range: tuple[int, int] | None = None
+    keyword_count: int | None = None
+    keyword_count_range: tuple[int, int] | None = None
+    duplicate_keywords: list[str] = dataclass_field(default_factory=list)
     unexpected_special_tokens: list[str] = dataclass_field(default_factory=list)
     keyword_overlap: KeywordOverlapState = "not_assessable"
     unchanged_draft_fields: list[str] = dataclass_field(default_factory=list)
@@ -3950,6 +3982,11 @@ class PromptQualitySignals:
     instruction_echo_fragments: tuple[str, ...] = ()
     unexpected_catalog_preamble: str | None = None
     missing_sections: tuple[str, ...] = ()
+    title_word_count: int | None = None
+    title_word_range: tuple[int, int] | None = None
+    keyword_count: int | None = None
+    keyword_count_range: tuple[int, int] | None = None
+    duplicate_keywords: tuple[str, ...] = ()
     keyword_overlap: KeywordOverlapState = "not_assessable"
     unchanged_draft_fields: tuple[str, ...] = ()
 
@@ -4020,12 +4057,33 @@ def _collect_prompt_quality_signals(
     prompt_bundle = _extract_trusted_hint_bundle(prompt, context_marker=context_marker)
     missing_sections: list[str] = []
     unexpected_preamble: str | None = None
-    if _prompt_requests_catalog_contract(prompt):
+    title_word_count: int | None = None
+    title_word_range: tuple[int, int] | None = None
+    keyword_count: int | None = None
+    keyword_count_range: tuple[int, int] | None = None
+    duplicate_keywords: tuple[str, ...] = ()
+    catalog_contract_requested = _prompt_requests_catalog_contract(prompt)
+    if catalog_contract_requested:
         missing_sections = _missing_catalog_sections(text)
         unexpected_preamble = _unexpected_catalog_preamble(text)
-    generated_keywords = _split_catalog_keywords(
-        _extract_catalog_sections(text).get("keywords", "")
-    )
+    sections = _extract_catalog_sections(text)
+    generated_keywords = _split_catalog_keywords(sections.get("keywords", ""))
+    if (
+        catalog_contract_requested
+        and not missing_sections
+        and all(sections.get(field) for field in ("title", "description", "keywords"))
+    ):
+        title_word_count = len(
+            re.findall(r"\b\w+(?:[-\u2019']\w+)*\b", sections["title"], re.UNICODE)
+        )
+        title_word_range = _catalog_requested_range(prompt, "title")
+        keyword_count = len(generated_keywords)
+        keyword_count_range = _catalog_requested_range(prompt, "keyword")
+        normalized_keywords = [
+            _normalize_phrase_for_matching(keyword) for keyword in generated_keywords
+        ]
+        counts = Counter(keyword for keyword in normalized_keywords if keyword)
+        duplicate_keywords = tuple(keyword for keyword, count in counts.items() if count > 1)
     keyword_overlap = _keyword_overlap_state(
         prompt_bundle.trusted_keywords,
         generated_keywords,
@@ -4040,6 +4098,11 @@ def _collect_prompt_quality_signals(
         instruction_echo_fragments=tuple(instruction_markers),
         unexpected_catalog_preamble=unexpected_preamble,
         missing_sections=tuple(missing_sections),
+        title_word_count=title_word_count,
+        title_word_range=title_word_range,
+        keyword_count=keyword_count,
+        keyword_count_range=keyword_count_range,
+        duplicate_keywords=duplicate_keywords,
         keyword_overlap=keyword_overlap,
         unchanged_draft_fields=unchanged_draft_fields,
     )
@@ -4120,6 +4183,11 @@ def analyze_generation_text(
         special_token_wrappers=list(normalized.removed_wrappers),
         configured_generation_wrappers=present_configured_wrappers,
         role_boundary_tokens=_configured_role_boundaries(text, normalized.removed_wrappers),
+        title_word_count=prompt_signals.title_word_count,
+        title_word_range=prompt_signals.title_word_range,
+        keyword_count=prompt_signals.keyword_count,
+        keyword_count_range=prompt_signals.keyword_count_range,
+        duplicate_keywords=list(prompt_signals.duplicate_keywords),
         unexpected_special_tokens=unexpected_special_tokens,
         keyword_overlap=prompt_signals.keyword_overlap,
         unchanged_draft_fields=list(prompt_signals.unchanged_draft_fields),
@@ -7029,6 +7097,7 @@ _OBSERVATION_DISPLAY_PRIORITY: Final[tuple[ObservationCode, ...]] = (
     "role_boundary_token_present",
     "thinking_trace_present",
     "configured_wrapper_present",
+    "catalog_constraint_violation",
     "minimal_output",
     "draft_returned_unchanged",
     "no_keyword_overlap",
@@ -7049,11 +7118,13 @@ _OBSERVATION_DISPLAY_LABELS: Final[dict[ObservationCode, str]] = {
     "thinking_trace_present": "Internal reasoning text remains visible",
     "thinking_trace_incomplete": "Internal reasoning block appears incomplete",
     "role_boundary_token_present": "Conversation-role control tokens remain visible",
+    "catalog_constraint_violation": "Title or keywords do not meet requested constraints",
     "no_keyword_overlap": "Keywords do not overlap the supplied keyword hints",
     "draft_returned_unchanged": (
         "Title, Description and Keywords copy all supplied hints unchanged"
     ),
 }
+_RANGE_ENDPOINT_COUNT: Final[int] = 2
 
 
 def _human_observation_labels(
@@ -7073,6 +7144,34 @@ def _human_observation_labels(
             if missing_sections:
                 fields = ", ".join(field.title() for field in missing_sections)
                 label = f"Missing or empty fields: {fields}"
+        elif code == "catalog_constraint_violation" and details is not None:
+            constraint_labels: list[str] = []
+            title_count = details.get("title_word_count")
+            title_range = details.get("title_word_range")
+            if (
+                title_count is not None
+                and title_range is not None
+                and len(title_range) == _RANGE_ENDPOINT_COUNT
+            ):
+                constraint_labels.append(
+                    f"Title has {title_count} words (requested {title_range[0]}-{title_range[1]})"
+                )
+            keyword_count = details.get("keyword_count")
+            keyword_range = details.get("keyword_count_range")
+            if (
+                keyword_count is not None
+                and keyword_range is not None
+                and len(keyword_range) == _RANGE_ENDPOINT_COUNT
+            ):
+                constraint_labels.append(
+                    "Keyword list has "
+                    f"{keyword_count} terms (requested {keyword_range[0]}-{keyword_range[1]})"
+                )
+            duplicate_keywords = details.get("duplicate_keywords")
+            if duplicate_keywords:
+                constraint_labels.append(f"Duplicate keywords: {', '.join(duplicate_keywords)}")
+            if constraint_labels:
+                label = "; ".join(constraint_labels)
         labels.append(label)
     return "; ".join(labels) or "none"
 
@@ -7318,6 +7417,22 @@ _DIAGNOSTICS_LIB_NAMES: Final[tuple[str, ...]] = (
     "huggingface-hub",
 )
 
+_ISSUE_RELEVANT_LIB_NAMES: Final[tuple[str, ...]] = (
+    "mlx-vlm",
+    "mlx",
+    "mlx-metal",
+    "mlx-lm",
+    "transformers",
+    "tokenizers",
+    "huggingface-hub",
+    "Pillow",
+)
+_ISSUE_RELEVANT_SYSTEM_KEYS: Final[tuple[str, ...]] = (
+    "Python Version",
+    "macOS Version",
+    "GPU/Chip",
+)
+
 
 @dataclass(frozen=True)
 class ResultAssessment:
@@ -7362,6 +7477,29 @@ def _execution_status(result: PerformanceResult) -> ExecutionStatus:
     return "completed" if result.success else "crashed"
 
 
+def _has_catalog_constraint_violation(analysis: GenerationQualityAnalysis) -> bool:
+    """Return whether recorded catalogue counts breach the requested contract."""
+    title_count_outside_range = (
+        analysis.title_word_count is not None
+        and analysis.title_word_range is not None
+        and not analysis.title_word_range[0]
+        <= analysis.title_word_count
+        <= analysis.title_word_range[1]
+    )
+    keyword_count_outside_range = (
+        analysis.keyword_count is not None
+        and analysis.keyword_count_range is not None
+        and not analysis.keyword_count_range[0]
+        <= analysis.keyword_count
+        <= analysis.keyword_count_range[1]
+    )
+    return (
+        title_count_outside_range
+        or keyword_count_outside_range
+        or bool(analysis.duplicate_keywords)
+    )
+
+
 def _assessment_observations(result: PerformanceResult) -> tuple[ObservationCode, ...]:
     """Project approved current-run facts into stable ordered observation codes."""
     text = _generation_text_value(result.generation)
@@ -7401,6 +7539,10 @@ def _assessment_observations(result: PerformanceResult) -> tuple[ObservationCode
         (analysis.has_thinking_trace, "thinking_trace_present"),
         (analysis.thinking_trace_incomplete, "thinking_trace_incomplete"),
         (bool(analysis.role_boundary_tokens), "role_boundary_token_present"),
+        (
+            _has_catalog_constraint_violation(analysis),
+            "catalog_constraint_violation",
+        ),
         (analysis.keyword_overlap == "no_overlap", "no_keyword_overlap"),
         (bool(analysis.unchanged_draft_fields), "draft_returned_unchanged"),
     )
@@ -7431,6 +7573,24 @@ def _assess_result(result: PerformanceResult) -> ResultAssessment:
     return ResultAssessment(execution, usability, maintainer_status, observations)
 
 
+def _catalog_constraint_observation_details(
+    analysis: GenerationQualityAnalysis,
+) -> JsonlObservationDetailsRecord:
+    """Return present catalogue-count evidence without adding empty fields."""
+    details: JsonlObservationDetailsRecord = {}
+    if analysis.title_word_count is not None:
+        details["title_word_count"] = analysis.title_word_count
+    if analysis.title_word_range is not None:
+        details["title_word_range"] = list(analysis.title_word_range)
+    if analysis.keyword_count is not None:
+        details["keyword_count"] = analysis.keyword_count
+    if analysis.keyword_count_range is not None:
+        details["keyword_count_range"] = list(analysis.keyword_count_range)
+    if analysis.duplicate_keywords:
+        details["duplicate_keywords"] = list(analysis.duplicate_keywords)
+    return details
+
+
 def _observation_details(result: PerformanceResult) -> JsonlObservationDetailsRecord:
     """Return non-empty exact evidence for the result's mechanical observations."""
     analysis = result.quality_analysis
@@ -7453,6 +7613,8 @@ def _observation_details(result: PerformanceResult) -> JsonlObservationDetailsRe
         details["thinking_trace_markers"] = list(analysis.thinking_trace_markers)
     if analysis.role_boundary_tokens:
         details["role_boundary_tokens"] = list(analysis.role_boundary_tokens)
+    if _has_catalog_constraint_violation(analysis):
+        details.update(_catalog_constraint_observation_details(analysis))
     if analysis.token_cap_reasons:
         details["token_cap_reasons"] = list(analysis.token_cap_reasons)
     if analysis.unchanged_draft_fields:
@@ -8485,23 +8647,45 @@ def _issue_provenance_blocks(
     system_info: Mapping[str, str],
 ) -> tuple[ReportBlock, ...]:
     """Build prompt and environment blocks for a direct crash issue draft."""
-    rows = tuple(
+    rows = list(
         _collect_report_component_rows(
             versions=library_versions,
             system_info=dict(system_info),
-            library_names=_DIAGNOSTICS_LIB_NAMES,
-            system_keys=_DIAGNOSTICS_SYSTEM_KEYS,
+            library_names=_ISSUE_RELEVANT_LIB_NAMES,
+            system_keys=_ISSUE_RELEVANT_SYSTEM_KEYS,
         )
     )
+    producer = _collect_check_models_provenance()
+    producer_parts = [producer["version"]]
+    if producer["git_revision"]:
+        producer_parts.append(f"revision {producer['git_revision']}")
+    dirty = producer.get("dirty")
+    if dirty is not None:
+        producer_parts.append("dirty" if dirty else "clean")
+    rows.append(("check_models", "; ".join(producer_parts)))
     components: ReportBlock = (
-        ReportTable(("Component", "Value"), rows)
+        ReportTable(("Component", "Value"), tuple(rows))
         if rows
         else ReportParagraph("Environment and component provenance unavailable.")
+    )
+    full_environment = ReportTable(
+        ("Evidence", "Link"),
+        (
+            (
+                "Complete dependency and toolchain inventory",
+                ReportTargetLink(
+                    "environment.log",
+                    _github_repo_artifact_url(_PUBLISHED_OUTPUT_ROOT / DEFAULT_ENV_OUTPUT.name),
+                ),
+            ),
+        ),
+        compact=True,
     )
     return (
         _report_section(
             "Provenance and Environment",
             _report_section("Components", components, level=3),
+            _report_section("Full environment evidence", full_environment, level=3),
         ),
     )
 
@@ -10861,15 +11045,49 @@ def _load_model(
         Tuple of ``(model, processor, config)`` where ``processor`` is an
         ``transformers.ProcessorMixin`` and ``config`` may be ``None``.
     """
-    model, processor = load(
-        path_or_hf_repo=params.model_identifier,
-        adapter_path=params.adapter_path,
-        lazy=params.lazy,
-        revision=params.revision,
-        trust_remote_code=params.trust_remote_code,
-        force_download=params.force_download,
-        quantize_activations=params.quantize_activations,
-    )
+    try:
+        model, processor = load(
+            path_or_hf_repo=params.model_identifier,
+            adapter_path=params.adapter_path,
+            lazy=params.lazy,
+            revision=params.revision,
+            trust_remote_code=params.trust_remote_code,
+            force_download=params.force_download,
+            quantize_activations=params.quantize_activations,
+        )
+    except Exception as load_error:
+        chain_text = " ".join(
+            f"{type(error).__name__}: {error}" for error in _exception_chain(load_error)
+        )
+        snapshot_path = (
+            _resolve_model_snapshot_path(params.model_identifier)
+            if not params.force_download and _has_external_connectivity_signal(chain_text)
+            else None
+        )
+        revision_matches = params.revision is None or (
+            snapshot_path is not None and snapshot_path.name == params.revision
+        )
+        if (
+            snapshot_path is None
+            or not snapshot_path.is_dir()
+            or str(snapshot_path) == params.model_identifier
+            or not revision_matches
+        ):
+            raise
+        logger.warning(
+            "Hub access failed while loading %s; retrying resolved local snapshot %s.",
+            params.model_identifier,
+            snapshot_path,
+        )
+        model, processor = load(
+            path_or_hf_repo=str(snapshot_path),
+            adapter_path=params.adapter_path,
+            lazy=params.lazy,
+            revision=None,
+            trust_remote_code=params.trust_remote_code,
+            force_download=False,
+            quantize_activations=params.quantize_activations,
+        )
     config = cast(
         "PreTrainedConfig | Mapping[str, object] | None",
         getattr(model, "config", None),
@@ -11032,11 +11250,6 @@ def _run_model_preflight_validators(
     if not callable(processor):
         _raise_preflight_error(
             "Loaded processor is not callable.",
-            phase="processor_load",
-        )
-    if getattr(processor, "image_processor", None) is None:
-        _raise_preflight_error(
-            "Loaded processor has no image_processor; expected multimodal processor.",
             phase="processor_load",
         )
 
@@ -14541,7 +14754,17 @@ def _collect_check_models_provenance() -> CheckModelsProvenanceRecord:
         install_type = "unknown"
     status = (
         _run_macos_toolchain_command(
-            ("git", "-C", str(_REPO_ROOT), "status", "--porcelain", "--untracked-files=no"),
+            (
+                "git",
+                "-C",
+                str(_REPO_ROOT),
+                "status",
+                "--porcelain",
+                "--untracked-files=no",
+                "--",
+                ".",
+                ":(exclude)src/output",
+            ),
             empty_output="",
         )
         if revision is not None
@@ -14703,6 +14926,7 @@ _RUN_ISSUE_OBSERVATION_VALUES: Final[frozenset[str]] = frozenset(
         "thinking_trace_present",
         "thinking_trace_incomplete",
         "role_boundary_token_present",
+        "catalog_constraint_violation",
         "no_keyword_overlap",
         "draft_returned_unchanged",
     }
@@ -14884,19 +15108,56 @@ def _narrow_run_issue_image(value: JsonLike) -> RunImageRecord | None:
     return record
 
 
+def _narrow_run_issue_producer(value: JsonLike) -> CheckModelsProvenanceRecord | None:
+    """Narrow optional producer facts used by the paste-ready run context."""
+    if not isinstance(value, dict):
+        return None
+    version_value = value.get("version")
+    if value.get("name") != "check_models" or not isinstance(version_value, str):
+        return None
+    install_type = value.get("install_type")
+    if install_type not in {"editable", "installed", "source-tree", "unknown"}:
+        return None
+    revision = value.get("git_revision")
+    dirty = value.get("dirty")
+    if revision is not None and not isinstance(revision, str):
+        return None
+    if dirty is not None and not isinstance(dirty, bool):
+        return None
+    record: CheckModelsProvenanceRecord = {
+        "name": "check_models",
+        "version": version_value,
+        "git_revision": revision,
+        "install_type": cast(
+            "Literal['editable', 'installed', 'source-tree', 'unknown']",
+            install_type,
+        ),
+    }
+    if "dirty" in value:
+        record["dirty"] = dirty
+    return record
+
+
 def _load_run_issue_enrichment(
     run_json_path: Path,
-) -> tuple[RunImageRecord | None, tuple[tuple[str, str], ...], bool | None]:
+) -> tuple[
+    RunImageRecord | None,
+    tuple[tuple[str, str], ...],
+    bool | None,
+    CheckModelsProvenanceRecord | None,
+]:
     """Load optional image/settings enrichment, ignoring absent or malformed run JSON."""
     image_record: RunImageRecord | None = None
     generation_settings: tuple[tuple[str, str], ...] = ()
     trust_remote_code: bool | None = None
+    producer: CheckModelsProvenanceRecord | None = None
     try:
         run_value: JsonLike = json.loads(_read_text_file(run_json_path))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         run_value = None
     if isinstance(run_value, dict):
         image_record = _narrow_run_issue_image(run_value.get("image"))
+        producer = _narrow_run_issue_producer(run_value.get("producer"))
         raw_trust_remote_code = run_value.get("trust_remote_code")
         if isinstance(raw_trust_remote_code, bool):
             trust_remote_code = raw_trust_remote_code
@@ -14906,7 +15167,7 @@ def _load_run_issue_enrichment(
                 (key, json.dumps(value, ensure_ascii=False, sort_keys=True))
                 for key, value in sorted(settings.items())
             )
-    return image_record, generation_settings, trust_remote_code
+    return image_record, generation_settings, trust_remote_code, producer
 
 
 def _load_run_issue_summary_source(
@@ -14921,8 +15182,10 @@ def _load_run_issue_summary_source(
         _validate_run_issue_result(value, line_number)
         for line_number, value in enumerate(parsed_rows[1:], start=2)
     )
-    image, generation_settings, trust_remote_code = (
-        _load_run_issue_enrichment(output_paths.run_json) if include_run_json else (None, (), None)
+    image, generation_settings, trust_remote_code, producer = (
+        _load_run_issue_enrichment(output_paths.run_json)
+        if include_run_json
+        else (None, (), None, None)
     )
 
     return RunIssueSummarySource(
@@ -14931,6 +15194,7 @@ def _load_run_issue_summary_source(
         image=image,
         generation_settings=generation_settings,
         trust_remote_code=trust_remote_code,
+        producer=producer,
     )
 
 
@@ -15217,10 +15481,54 @@ def _run_issue_summary_surfaced_sections(
         "crashed": "Crashed attempts requiring review",
         "indeterminate": "Indeterminate attempts requiring review",
     }
+    priority = {code: index for index, code in enumerate(_OBSERVATION_DISPLAY_PRIORITY)}
+
+    usability_priority = {
+        "unusable": 0,
+        "usable_with_caveats": 1,
+        "usable": 2,
+        "not_evaluated": 3,
+    }
+
+    def _sort_key(result: JsonlResultRecord) -> tuple[int, int, str]:
+        observations = result["assessment"]["observations"]
+        severity = min((priority[code] for code in observations), default=len(priority))
+        usability = usability_priority[result["assessment"]["usability"]]
+        return severity, usability, result["model"].casefold()
+
+    def _observed_result(result: JsonlResultRecord) -> str:
+        assessment = result["assessment"]
+        if assessment["observations"]:
+            return _human_observation_labels(
+                assessment["observations"],
+                details=assessment.get("details"),
+            )
+        failure = result.get("failure")
+        if failure is None:
+            return "No assessment evidence was captured"
+        phase = failure.get("phase")
+        phase_label = {
+            "model_load": "model loading",
+            "processor_load": "processor loading",
+            "tokenizer_load": "tokenizer loading",
+            "prefill": "prompt preparation",
+            "decode": "generation",
+        }.get(phase or "", (phase or "execution").replace("_", " "))
+        message = failure.get("message") or ""
+        if "connection reset" in message.casefold():
+            return f"Network connection reset during {phase_label}"
+        stage = failure.get("stage")
+        if stage:
+            return f"{stage} during {phase_label}"
+        exception_type = failure.get("exception_type")
+        if exception_type:
+            return f"{exception_type} during {phase_label}"
+        return f"Attempt stopped during {phase_label}"
+
     sections: list[ReportSection] = []
     for execution, heading in heading_by_execution.items():
         rows: list[tuple[ReportCell, ...]] = []
-        for result in results:
+        for result in sorted(results, key=_sort_key):
             assessment = result["assessment"]
             if assessment["execution"] != execution:
                 continue
@@ -15228,10 +15536,7 @@ def _run_issue_summary_surfaced_sections(
                 (
                     result["model"],
                     assessment["usability"].replace("_", " "),
-                    _human_observation_labels(
-                        assessment["observations"],
-                        details=assessment.get("details"),
-                    ),
+                    _observed_result(result),
                     _run_issue_summary_artifact_link(
                         summary_path=summary_path,
                         artifact_path=output_paths.diagnostics,
@@ -15267,6 +15572,15 @@ def _run_issue_summary_context_section(source: RunIssueSummarySource) -> ReportS
             )
         )
     rows.extend((f"Generation: {key}", value) for key, value in source.generation_settings)
+    if source.trust_remote_code is not None:
+        rows.append(("Trust remote code", str(source.trust_remote_code).lower()))
+    if source.producer is not None:
+        producer = source.producer
+        rows.append(("check_models version", producer["version"]))
+        if producer["git_revision"] is not None:
+            rows.append(("check_models revision", producer["git_revision"]))
+        if (dirty := producer.get("dirty")) is not None:
+            rows.append(("check_models source dirty", str(dirty).lower()))
     versions = source.metadata.get("library_versions", {})
     if isinstance(versions, dict):
         rows.extend(
@@ -15280,7 +15594,16 @@ def _run_issue_summary_context_section(source: RunIssueSummarySource) -> ReportS
         for label in ("macOS Version", "GPU/Chip", "Python Version")
         if system.get(label)
     )
-    return ReportSection("Run context", (ReportKeyValues(tuple(rows)),))
+    return ReportSection(
+        "Run context",
+        (
+            ReportKeyValues(tuple(rows)),
+            ReportParagraph(
+                "GitHub links target the repository's mutable main branch; use the committed "
+                "output snapshot when durable issue evidence is required."
+            ),
+        ),
+    )
 
 
 def _run_issue_summary_artifacts_section(

--- a/src/tests/test_dependency_sync.py
+++ b/src/tests/test_dependency_sync.py
@@ -1666,6 +1666,7 @@ def test_quality_script_runs_skylos_quality_gate() -> None:
     assert 'echo "=== Skylos Audit Gate ==="' in quality_script
     assert "SKYLOS_JOBS" not in quality_script
     assert "--danger" not in quality_script
+    assert quality_script.count('"!**/.worktrees/**"') == 2
     assert re.search(
         r"TERM=dumb NO_COLOR=1 CLICOLOR=0 FORCE_COLOR=0 PY_COLORS=0\s+\\?\s*"
         r"quality_run_python_tool skylos \. --quality --secrets --sca --gate --no-upload "
@@ -1987,22 +1988,26 @@ def test_should_audit_path_excludes_generated_and_archived_paths(tmp_path: Path)
     included = repo_root / "src" / "module.py"
     excluded_build = repo_root / "src" / "build" / "lib" / "check_models.py"
     excluded_conda = repo_root / ".conda" / "lib" / "python3.13" / "site.py"
+    excluded_worktree = repo_root / ".worktrees" / "upstream" / "module.py"
     excluded_output = repo_root / "src" / "output" / "results.md"
     excluded_archived = repo_root / "src" / "tools" / ".archived" / "old.py"
     included.parent.mkdir(parents=True)
     excluded_build.parent.mkdir(parents=True)
     excluded_conda.parent.mkdir(parents=True)
+    excluded_worktree.parent.mkdir(parents=True)
     excluded_output.parent.mkdir(parents=True)
     excluded_archived.parent.mkdir(parents=True)
     included.write_text("print('ok')\n", encoding="utf-8")
     excluded_build.write_text("value = 1  # noqa: F401\n", encoding="utf-8")
     excluded_conda.write_text("value = 1  # noqa: F401\n", encoding="utf-8")
+    excluded_worktree.write_text("value = 1  # noqa: F401\n", encoding="utf-8")
     excluded_output.write_text("<!-- markdownlint-disable MD028 -->\n", encoding="utf-8")
     excluded_archived.write_text("x = 1  # noqa: F841\n", encoding="utf-8")
 
     assert check_suppressions.should_audit_path(included, repo_root) is True
     assert check_suppressions.should_audit_path(excluded_build, repo_root) is False
     assert check_suppressions.should_audit_path(excluded_conda, repo_root) is False
+    assert check_suppressions.should_audit_path(excluded_worktree, repo_root) is False
     assert check_suppressions.should_audit_path(excluded_output, repo_root) is False
     assert check_suppressions.should_audit_path(excluded_archived, repo_root) is False
 

--- a/src/tests/test_jsonl_output.py
+++ b/src/tests/test_jsonl_output.py
@@ -429,6 +429,23 @@ def test_check_models_provenance_records_dirty_source_tree(
     assert check_models._collect_check_models_provenance()["dirty"] is True
 
 
+def test_check_models_provenance_ignores_generated_output_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Writing retained artifacts must not make the producer mark itself dirty."""
+    monkeypatch.setattr(check_models, "version", lambda _name: "0.9.0")
+    monkeypatch.setattr(check_models, "_distribution_is_editable", lambda _name: True)
+
+    def git_probe(command: tuple[str, ...], **_kwargs: object) -> str:
+        if "status" not in command:
+            return "abc123"
+        return "" if ":(exclude)src/output" in command else " M src/output/run.json"
+
+    monkeypatch.setattr(check_models, "_run_macos_toolchain_command", git_probe)
+
+    assert check_models._collect_check_models_provenance()["dirty"] is False
+
+
 def test_component_provenance_captures_editable_source_without_home_disclosure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -490,6 +507,41 @@ def test_model_provenance_distinguishes_requested_and_resolved_revision(
         "requested_revision": "main",
         "resolved_revision": snapshot_sha,
         "snapshot_path": ("~/.cache/huggingface/hub/models--org--model/snapshots/" + snapshot_sha),
+    }
+
+
+def test_catalog_constraint_details_are_emitted_only_for_a_violation() -> None:
+    """Routine counts must not bloat rows without the matching observation."""
+    compliant = PerformanceResult(
+        model_name="org/compliant",
+        generation=MockGeneration(),
+        success=True,
+        quality_analysis=check_models.GenerationQualityAnalysis(
+            is_repetitive=False,
+            repeated_token=None,
+            title_word_count=5,
+            title_word_range=(5, 10),
+            keyword_count=10,
+            keyword_count_range=(10, 18),
+        ),
+    )
+    violation = dataclasses.replace(
+        compliant,
+        model_name="org/violation",
+        quality_analysis=dataclasses.replace(
+            _require_present(compliant.quality_analysis, field_name="quality_analysis"),
+            title_word_count=4,
+            duplicate_keywords=["halesworth"],
+        ),
+    )
+
+    assert check_models._observation_details(compliant) == {}
+    assert check_models._observation_details(violation) == {
+        "title_word_count": 4,
+        "title_word_range": [5, 10],
+        "keyword_count": 10,
+        "keyword_count_range": [10, 18],
+        "duplicate_keywords": ["halesworth"],
     }
 
 

--- a/src/tests/test_markdown_formatting.py
+++ b/src/tests/test_markdown_formatting.py
@@ -397,7 +397,7 @@ def test_gallery_uses_short_observation_labels_without_review_prose(tmp_path: Pa
 
     assert "*Why:*" not in md
     assert "*Next action:*" not in md
-    assert "*Observations:* none" in md
+    assert "*Observations:* Title or keywords do not meet requested constraints" in md
     assert "Keyword count violation" not in md
 
 

--- a/src/tests/test_process_image_mock.py
+++ b/src/tests/test_process_image_mock.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from transformers.processing_utils import ProcessorMixin
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
@@ -68,6 +69,16 @@ class _FakeLegacyProcessor:
     @staticmethod
     def batch_decode(*_args: object, **_kwargs: object) -> list[str]:
         return []
+
+
+class _FakeStepProcessor(_FakeLegacyProcessor, ProcessorMixin):
+    """Callable image processor without an ``image_processor`` attribute."""
+
+    def __init__(self) -> None:
+        """Skip ProcessorMixin construction; the preflight needs only interfaces."""
+
+    def __call__(self, *_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
 
 
 class _FakeMxRuntime:
@@ -309,6 +320,86 @@ class TestProcessImageWithModelMock:
         assert config is fake_model.config
         assert mock_load.call_args.kwargs["force_download"] is True
         assert mock_load.call_args.kwargs["quantize_activations"] is True
+
+    def test_load_model_retries_connectivity_failure_from_local_snapshot(
+        self,
+        test_image: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A transient Hub read must not block an already-cached model."""
+        params = _build_params(test_image)
+        snapshot = tmp_path / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        fake_model = _FakeModel()
+        fake_processor = _FakeProcessor()
+
+        with (
+            patch.object(
+                check_models,
+                "load",
+                side_effect=[OSError("connection reset by peer"), (fake_model, fake_processor)],
+            ) as mock_load,
+            patch.object(
+                check_models,
+                "_resolve_model_snapshot_path",
+                return_value=snapshot,
+            ),
+        ):
+            model, processor, config = check_models._load_model(params)
+
+        assert model is fake_model
+        assert processor is fake_processor
+        assert config is fake_model.config
+        assert [call.kwargs["path_or_hf_repo"] for call in mock_load.call_args_list] == [
+            params.model_identifier,
+            str(snapshot),
+        ]
+
+    @pytest.mark.parametrize(
+        ("load_error", "revision", "force_download"),
+        [
+            (ValueError("unsupported model config"), None, False),
+            (OSError("connection reset by peer"), "different-revision", False),
+            (OSError("connection reset by peer"), None, True),
+        ],
+    )
+    def test_load_model_does_not_retry_unsafe_local_fallbacks(
+        self,
+        test_image: Path,
+        tmp_path: Path,
+        load_error: Exception,
+        revision: str | None,
+        force_download: bool,
+    ) -> None:
+        """Only unpinned ordinary connectivity failures may use cached state."""
+        params = replace(
+            _build_params(test_image),
+            revision=revision,
+            force_download=force_download,
+        )
+        snapshot = tmp_path / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+
+        with (
+            patch.object(check_models, "load", side_effect=load_error) as mock_load,
+            patch.object(
+                check_models,
+                "_resolve_model_snapshot_path",
+                return_value=snapshot,
+            ),
+            pytest.raises(type(load_error), match=str(load_error)),
+        ):
+            check_models._load_model(params)
+
+        assert mock_load.call_count == 1
+
+    def test_preflight_accepts_custom_image_processor_without_attribute(self) -> None:
+        """Native-compatible custom processors need not expose HF internals."""
+        check_models._run_model_preflight_validators(
+            model_identifier="org/step",
+            processor=_FakeStepProcessor(),
+            config={"model_type": "step3p7"},
+        )
 
     def test_timeout_returns_failure(self, test_image: Path) -> None:
         """TimeoutError during generation should produce success=False."""

--- a/src/tests/test_quality_analysis.py
+++ b/src/tests/test_quality_analysis.py
@@ -182,6 +182,106 @@ def test_token_cap_alone_is_neutral() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("title", "keywords", "expected_title_words", "expected_keyword_count", "duplicates"),
+    [
+        (
+            "Four Word Title Here",
+            "one, two, three, four, five, six, seven, eight, nine, ten",
+            4,
+            10,
+            [],
+        ),
+        (
+            "Five Word Catalogue Title Here",
+            (
+                "one, two, three, four, five, six, seven, eight, nine, ten, eleven, "
+                "twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen"
+            ),
+            5,
+            19,
+            [],
+        ),
+        (
+            "Five Word Catalogue Title Here",
+            "Halesworth, sky, brick, windows, sign, gravel, clouds, arts, building, halesworth",
+            5,
+            10,
+            ["halesworth"],
+        ),
+    ],
+)
+def test_catalog_constraint_violations_are_repairable_caveats(
+    title: str,
+    keywords: str,
+    expected_title_words: int,
+    expected_keyword_count: int,
+    duplicates: list[str],
+) -> None:
+    """Counts and duplicates should qualify otherwise complete catalogue output."""
+    result = _result(
+        f"Title: {title}\n"
+        "Description: A factual description of the visible building.\n"
+        f"Keywords: {keywords}",
+        prompt=CATALOG_PROMPT,
+    )
+
+    assert result.quality_analysis is not None
+    assert result.quality_analysis.title_word_count == expected_title_words
+    assert result.quality_analysis.keyword_count == expected_keyword_count
+    assert result.quality_analysis.duplicate_keywords == duplicates
+    assert check_models._assess_result(result) == check_models.ResultAssessment(
+        "completed",
+        "usable_with_caveats",
+        "observation_needs_reproduction",
+        ("catalog_constraint_violation",),
+    )
+
+
+def test_compliant_catalog_constraints_remain_clean() -> None:
+    result = _result(
+        "Title: Five Word Catalogue Title Here\n"
+        "Description: A factual description of the visible building.\n"
+        "Keywords: one, two, three, four, five, six, seven, eight, nine, ten",
+        prompt=CATALOG_PROMPT,
+    )
+
+    assert check_models._assess_result(result) == check_models.ResultAssessment(
+        "completed", "usable", "none", ()
+    )
+
+
+def test_catalog_constraints_are_not_inferred_for_an_unrelated_prompt() -> None:
+    result = _result(
+        "Title: Brief title\nDescription: A factual description.\nKeywords: repeated, repeated",
+        prompt="Describe the response format used in this example.",
+    )
+
+    assert result.quality_analysis is not None
+    assert result.quality_analysis.title_word_count is None
+    assert result.quality_analysis.keyword_count is None
+    assert result.quality_analysis.duplicate_keywords == []
+    assert "catalog_constraint_violation" not in check_models._assess_result(result).observations
+
+
+def test_configured_utterance_boundary_is_reported_when_visible() -> None:
+    text = (
+        "Title: Five Word Catalogue Title Here\n"
+        "Description: A factual description of the visible building.\n"
+        "Keywords: one, two, three, four, five, six, seven, eight, nine, ten"
+        "<end_of_utterance>"
+    )
+    result = _result(
+        text,
+        prompt=CATALOG_PROMPT,
+        known_special_tokens=("<end_of_utterance>",),
+    )
+
+    assert result.quality_analysis is not None
+    assert result.quality_analysis.role_boundary_tokens == ["<end_of_utterance>"]
+    assert check_models._assess_result(result).observations == ("role_boundary_token_present",)
+
+
 def test_missing_generation_count_does_not_make_complete_output_minimal() -> None:
     result = check_models.PerformanceResult(
         model_name="example/model",
@@ -372,7 +472,7 @@ def test_assisted_output_returning_every_supplied_draft_field_is_observed_exactl
         "completed",
         "usable_with_caveats",
         "observation_needs_reproduction",
-        ("draft_returned_unchanged",),
+        ("catalog_constraint_violation", "draft_returned_unchanged"),
     )
 
 

--- a/src/tests/test_report_generation.py
+++ b/src/tests/test_report_generation.py
@@ -237,6 +237,13 @@ def _write_issue_summary_fixture(
                     if trust_remote_code is not None
                     else {}
                 ),
+                "producer": {
+                    "name": "check_models",
+                    "version": "0.8.9",
+                    "git_revision": "abc123",
+                    "install_type": "source-tree",
+                    "dirty": False,
+                },
             }
         )
         + "\n",
@@ -378,9 +385,85 @@ def test_run_issue_summary_expands_crash_and_tables_other_findings(tmp_path: Pat
         for target in link_targets
     )
     assert "1 clean completion; see the [full model gallery]" in content
+    assert "Trust remote code" in content
+    assert "check_models" in content
+    assert "0.8.9" in content
+    assert "abc123" in content
+    assert "GitHub links" in content
+    assert "mutable" in content
     assert "org/clean" not in content
     assert "Traceback (most recent call last)" not in content
     assert "generated output that must not be copied" not in content
+
+
+def test_run_issue_summary_uses_failure_reason_when_observations_are_empty(
+    tmp_path: Path,
+) -> None:
+    """An indeterminate row should say what prevented evaluation."""
+    output_paths = _issue_summary_output_paths(tmp_path / "output")
+    result = _issue_summary_result(
+        "org/network",
+        execution="indeterminate",
+        usability="not_evaluated",
+    )
+    result["failure"] = {
+        "phase": "model_load",
+        "stage": "Network Error",
+        "code": "UNKNOWN_MODEL_LOAD_NETWORK_ERROR",
+        "message": "Model loading failed: [Errno 54] Connection reset by peer",
+        "exception_type": "ReadError",
+        "exception_module": "httpx",
+        "package": "unknown",
+        "traceback": "heavy evidence",
+        "exception_chain": [],
+    }
+    _write_issue_summary_fixture(output_paths, results=(result,))
+
+    summary = check_models.generate_run_issue_summary_report(output_paths)
+
+    if summary is None:
+        pytest.fail("the indeterminate result must produce a summary")
+    content = summary.read_text(encoding="utf-8")
+    assert "Network connection reset during model loading" in content
+    assert "| org/network | not evaluated | none |" not in content
+
+
+def test_run_issue_summary_sorts_review_rows_by_observation_severity(tmp_path: Path) -> None:
+    """Grossly unusable outputs should be visible before repairable caveats."""
+    output_paths = _issue_summary_output_paths(tmp_path / "output")
+    _write_issue_summary_fixture(
+        output_paths,
+        results=(
+            _issue_summary_result(
+                "org/count-caveat",
+                usability="usable_with_caveats",
+                maintainer_status="observation_needs_reproduction",
+                observations=["catalog_constraint_violation"],
+                details={"title_word_count": 4, "title_word_range": [5, 10]},
+            ),
+            _issue_summary_result(
+                "org/missing",
+                usability="unusable",
+                maintainer_status="observation_needs_reproduction",
+                observations=["missing_requested_sections"],
+            ),
+            _issue_summary_result(
+                "org/repeated",
+                usability="unusable",
+                maintainer_status="observation_needs_reproduction",
+                observations=["repeated_output"],
+            ),
+        ),
+    )
+
+    summary = check_models.generate_run_issue_summary_report(output_paths)
+
+    if summary is None:
+        pytest.fail("the observed results must produce a summary")
+    content = summary.read_text(encoding="utf-8")
+    assert content.index("| org/repeated |") < content.index("| org/missing |")
+    assert content.index("| org/missing |") < content.index("| org/count-caveat |")
+    assert "Title has 4 words (requested 5-10)" in content
 
 
 def test_run_issue_summary_builds_complete_public_image_reproduction(tmp_path: Path) -> None:
@@ -2229,8 +2312,27 @@ def test_html_chooser_is_sortable_and_surfaces_prefill_first_token_time(
 
 def test_crash_diagnostics_and_issue_draft_keep_complete_primary_evidence_first(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A crash draft should repeat complete diagnostics evidence without truncation."""
+    monkeypatch.setattr(
+        check_models,
+        "_collect_check_models_provenance",
+        lambda: {
+            "name": "check_models",
+            "version": "0.8.9",
+            "git_revision": "abc123def456",
+            "install_type": "source-tree",
+            "dirty": False,
+        },
+    )
+    system_info = {
+        "Python Version": "3.13.13",
+        "macOS Version": "26.6",
+        "GPU/Chip": "Apple M5 Max",
+        "SDK Version": "26.0",
+        "Apple Clang Version": "17.0.0",
+    }
     traceback_text = "\n".join(
         (
             "Traceback (most recent call last):",
@@ -2277,7 +2379,7 @@ def test_crash_diagnostics_and_issue_draft_keep_complete_primary_evidence_first(
     context = _build_report_render_context(
         results=[crash],
         prompt="Describe the image.",
-        system_info={},
+        system_info=system_info,
     )
     diagnostics = tmp_path / "diagnostics.md"
     generate_diagnostics_report(
@@ -2285,14 +2387,14 @@ def test_crash_diagnostics_and_issue_draft_keep_complete_primary_evidence_first(
         diagnostics,
         prompt="Describe the image.",
         library_versions=_stub_versions(),
-        system_info={},
+        system_info=system_info,
         report_context=context,
     )
     generated = _generate_github_issue_reports(
         report_context=context,
         output_dir=tmp_path,
         library_versions=_stub_versions(),
-        system_info={},
+        system_info=system_info,
         prompt="Describe the image.",
     )
 
@@ -2324,6 +2426,20 @@ def test_crash_diagnostics_and_issue_draft_keep_complete_primary_evidence_first(
     assert issue_content.index("## Reproduction inputs") < issue_content.index(
         "## Provenance and Environment"
     )
+    for expected in (
+        "mlx-vlm",
+        "mlx",
+        "transformers",
+        "tokenizers",
+        "Python Version",
+        "macOS Version",
+        "GPU/Chip",
+        "abc123def456",
+        "https://github.com/jrp2014/check_models/blob/main/src/output/environment.log",
+    ):
+        assert expected in issue_content
+    assert "SDK Version" not in issue_content
+    assert "Apple Clang Version" not in issue_content
     assert not (tmp_path / "issues" / "index.md").exists()
 
 
@@ -3445,7 +3561,9 @@ class TestRetainedMarkdownArtifactEdges:
                 assert relative_targets == []
             else:
                 assert relative_targets
-                assert github_output_targets == []
+                assert github_output_targets == [
+                    "https://github.com/jrp2014/check_models/blob/main/src/output/environment.log"
+                ]
 
             html_content = output_paths.html.read_text(encoding="utf-8")
             jsonl_records = [

--- a/src/tools/check_suppressions.py
+++ b/src/tools/check_suppressions.py
@@ -32,6 +32,7 @@ SHELL_SUFFIXES: Final[frozenset[str]] = frozenset({".sh"})
 EXCLUDED_PATH_PARTS: Final[frozenset[str]] = frozenset(
     {
         ".conda",
+        ".worktrees",
         "__pycache__",
         ".pytest_cache",
         "node_modules",

--- a/src/tools/run_quality_checks.sh
+++ b/src/tools/run_quality_checks.sh
@@ -115,7 +115,8 @@ if [ "$QUALITY_MODE" = "fast" ]; then
         --config .markdownlint.jsonc \
         "**/*.md" \
         "!src/node_modules/**" \
-        "!**/node_modules/**"
+        "!**/node_modules/**" \
+        "!**/.worktrees/**"
 
     echo ""
     echo "✅ Fast quality checks passed!"
@@ -143,7 +144,8 @@ quality_run_markdownlint \
     --config .markdownlint.jsonc \
     "**/*.md" \
     "!src/node_modules/**" \
-    "!**/node_modules/**"
+    "!**/node_modules/**" \
+    "!**/.worktrees/**"
 
 echo ""
 echo "✅ All quality checks passed!"


### PR DESCRIPTION
## Summary

- accept native-compatible custom processors without requiring an `image_processor` attribute
- retry connectivity-only Hub load failures from a matching local snapshot
- record catalogue count/duplicate caveats and visible turn/message/utterance tokens
- make the paste-ready run summary severity-ordered, failure-explanatory, and producer-provenance complete
- narrow direct crash-draft environment tables while linking the canonical full environment artifact
- exclude ignored `.worktrees/` checkouts from suppression and Markdown quality audits

## Ownership findings

The 2 August run did not coincide with a Transformers/tokenizers or relevant mlx-vlm generation-path update. Native isolation showed:

- Step-3.7 succeeds through native mlx-vlm; its check_models crash was the harness's `image_processor` preflight assumption.
- Molmo returns an empty answer for the long catalogue prompt at both full and reduced image sizes, but captions the same reduced image with a short prompt. That is prompt-following capacity, not an image-size/runtime failure.
- Idefics3's literal `<end_of_utterance>` reproduces natively and disappears when that declared token is used as EOS. The upstream fix is in [Blaizzy/mlx-vlm#1774](https://github.com/Blaizzy/mlx-vlm/pull/1774).
- The other repeated, thinking, and protocol-token outputs do not establish mlx-vlm runtime defects without smaller native reproductions.

The retained `src/output/` snapshot is intentionally unchanged; a rerun will acquire the improved behavior.

## Validation

- `make format`
- `make -C src lint-fix`
- `make lint`
- `make quality` — 808 tests passed; Ruff, mypy, ty, Pyrefly, suppression audit, Vulture, Skylos, ShellCheck, and Markdown lint all passed
- focused red/green tests cover custom processors, safe cache fallback, catalogue constraints, escaped utterance tokens, issue-summary ordering/failure labels/provenance, crash environment scope, and `.worktrees/` audit isolation
